### PR TITLE
Add zh-CN localization strings for updates

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -23,7 +23,7 @@
 
     <string name="no_devices_connected">未连接设备</string>
     <plurals name="connected_devices_count">
-        <item quantity="one">已连接 %1$d 台设备</item>
+
         <item quantity="other">已连接 %1$d 台设备</item>
     </plurals>
     <string name="cd_add_device">添加设备</string>
@@ -481,7 +481,7 @@
     <string name="adb_misc_dialog_density_title">设置屏幕密度（DPI）</string>
     <string name="adb_misc_density_reading">正在读取当前屏幕密度…</string>
     <string name="adb_misc_density_presets">预设</string>
-    <string name="adb_misc_density_custom_label">自定义 DPI 值（72 - 1200）</string>
+    <string name="adb_misc_density_custom_label">自定义 DPI 值（72 – 1200）</string>
     <string name="adb_misc_density_invalid">请输入 72 到 1200 之间的有效 DPI</string>
     <string name="adb_misc_btn_apply">应用</string>
     <string name="adb_misc_btn_reset_default">恢复默认值</string>
@@ -839,11 +839,11 @@
     <string name="notification_keep_alive_text">Dioxamine 正在后台运行</string>
     <string name="notification_keep_alive_no_devices">未连接设备 &#8226; 正在后台运行</string>
     <plurals name="notification_adb_devices">
-        <item quantity="one">已连接 %1$d 台 ADB 设备</item>
+
         <item quantity="other">已连接 %1$d 台 ADB 设备</item>
     </plurals>
     <plurals name="notification_fastboot_devices">
-        <item quantity="one">已连接 %1$d 台 Fastboot 设备</item>
+
         <item quantity="other">已连接 %1$d 台 Fastboot 设备</item>
     </plurals>
     <string name="notification_keep_alive_stop_action">停止</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -138,6 +138,7 @@
     <string name="section_video_source">视频源</string>
     <string name="video_source_screen">屏幕</string>
     <string name="video_source_camera">摄像头</string>
+    <string name="camera_source_subtitle_req">需要 Android 12+（API 31），当前设备为 API %1$d。</string>
 
     <string name="section_camera">摄像头</string>
     <string name="camera_facing_back">后置</string>
@@ -234,6 +235,9 @@
 
     <string name="settings_language_title">语言</string>
     <string name="settings_language_system_default">跟随系统</string>
+
+
+
     <string name="settings_language_contribute">参与翻译</string>
 
     <string name="settings_theme_title">主题</string>
@@ -241,6 +245,10 @@
     <string name="theme_light">浅色</string>
     <string name="theme_dark">深色</string>
     <string name="theme_amoled">AMOLED</string>
+    <string name="settings_theme_dynamic_title">动态配色（Monet）</string>
+    <string name="settings_theme_dynamic_desc">使用系统壁纸配色</string>
+    <string name="settings_theme_dynamic_req">需要 Android 12+</string>
+    <string name="settings_theme_mode_header">主题模式</string>
 
     <string name="settings_logs_title">应用日志</string>
     <string name="settings_logs_subtitle">导出或清除持久化的应用日志</string>
@@ -353,8 +361,18 @@
     <string name="pkg_manager_action_pull">提取应用（导出 APK）</string>
     <string name="pkg_manager_action_uninstall">卸载应用</string>
     <string name="pkg_manager_action_force_stop">强制停止</string>
-    <string name="pkg_manager_force_stop_success">已强制停止 %1$s</string>
+    <string name="pkg_manager_action_permissions">授予权限</string>
     <string name="pkg_manager_action_info">应用信息</string>
+    <string name="pkg_manager_dialog_permissions_title">授予权限</string>
+    <string name="pkg_manager_custom_perm_placeholder">例如 android.permission.WRITE_SECURE_SETTINGS</string>
+    <string name="pkg_manager_perm_prompt">输入要授予的权限名称：</string>
+    <string name="pkg_manager_perm_label">权限名称</string>
+    <string name="pkg_manager_perm_manifest_note">注意：目标应用必须在其 AndroidManifest.xml 中声明此权限。</string>
+    <string name="pkg_manager_perm_invalid_format">权限格式无效（例如 android.permission.WRITE_SECURE_SETTINGS）</string>
+    <string name="pkg_manager_btn_grant">授予</string>
+    <string name="pkg_manager_perm_granted">已授予 %1$s</string>
+    <string name="pkg_manager_perm_failed">失败：%1$s</string>
+    <string name="pkg_manager_force_stop_success">已强制停止 %1$s</string>
     <string name="pkg_manager_install_apks">安装 APK</string>
     <string name="pkg_manager_installing">正在设备上安装应用…</string>
     <string name="pkg_manager_install_success">应用安装成功</string>
@@ -396,6 +414,110 @@
     <string name="adb_screenshot_saved">截图已成功保存</string>
     <string name="adb_screenshot_failed">截取屏幕失败：%1$s</string>
     <string name="adb_screenshot_empty">点按“截取屏幕”以截取已连接设备的画面。</string>
+
+    <!-- 通用按钮 -->
+    <string name="btn_back">返回</string>
+
+    <!-- ADB 杂项工具 -->
+    <string name="adb_misc_tile_title">杂项工具</string>
+    <string name="adb_misc_tile_desc">显示控制、开发者调整和快捷操作</string>
+    <string name="adb_misc_section_app_process">应用和进程操作</string>
+    <string name="adb_misc_section_display">显示和方向</string>
+    <string name="adb_misc_section_system_ui">系统界面和通知</string>
+    <string name="adb_misc_section_dev_tweaks">开发者和界面调整</string>
+    <string name="adb_misc_section_battery">电池模拟</string>
+    <string name="adb_misc_section_intent_url">Intent 和 URL</string>
+
+    <string name="adb_misc_kill_app_title">终止前台应用</string>
+    <string name="adb_misc_kill_app_desc">强制停止目标设备屏幕上当前打开的应用</string>
+    <string name="adb_misc_clear_app_title">清除前台应用数据</string>
+    <string name="adb_misc_clear_app_desc">重置当前活动应用的数据和缓存</string>
+
+    <string name="adb_misc_orientation_title">设置屏幕方向</string>
+    <string name="adb_misc_orientation_desc">强制设为 0° 竖屏、90° 横屏、180° 倒置或 270° 横屏</string>
+    <string name="adb_misc_auto_rotate_title">开关自动旋转</string>
+    <string name="adb_misc_auto_rotate_desc">开启或关闭基于加速度传感器的屏幕旋转</string>
+    <string name="adb_misc_density_title">屏幕密度（DPI）</string>
+    <string name="adb_misc_density_desc">更改显示 DPI 缩放或恢复设备默认值</string>
+    <string name="adb_misc_density_current">当前值：%1$s</string>
+    <string name="adb_misc_density_placeholder">例如 420</string>
+    <string name="adb_misc_resolution_title">屏幕分辨率</string>
+    <string name="adb_misc_resolution_desc">更改屏幕分辨率尺寸（宽 × 高）或将其重置</string>
+    <string name="adb_misc_size_current">当前值：%1$s</string>
+    <string name="adb_misc_size_placeholder">例如 1080x2400</string>
+    <string name="adb_misc_stay_awake_title">保持屏幕常亮</string>
+    <string name="adb_misc_stay_awake_desc">USB 连接期间防止目标设备屏幕休眠</string>
+
+    <string name="adb_misc_expand_notifs_title">展开通知栏</string>
+    <string name="adb_misc_expand_notifs_desc">下拉通知面板</string>
+    <string name="adb_misc_expand_qs_title">展开快捷设置</string>
+    <string name="adb_misc_expand_qs_desc">下拉快捷设置磁贴面板</string>
+    <string name="adb_misc_collapse_statusbar_title">收起状态栏</string>
+    <string name="adb_misc_collapse_statusbar_desc">关闭所有已展开的通知或快捷设置面板</string>
+
+    <string name="adb_misc_demo_mode_title">演示模式（整洁状态栏）</string>
+    <string name="adb_misc_demo_mode_desc">显示 100% 电量、12:00 时间和满格信号，并隐藏通知</string>
+    <string name="adb_misc_show_touches_title">开关显示点按操作</string>
+    <string name="adb_misc_show_touches_desc">在手指点按处显示可视触摸圆点</string>
+    <string name="adb_misc_pointer_location_title">开关指针位置</string>
+    <string name="adb_misc_pointer_location_desc">显示触摸坐标标尺和轨迹叠加层</string>
+    <string name="adb_misc_anim_scale_title">窗口动画速度</string>
+    <string name="adb_misc_anim_scale_desc">调整窗口、过渡和动画程序时长缩放（0x 至 2x）</string>
+
+    <string name="adb_misc_battery_sim_title">模拟电池状态</string>
+    <string name="adb_misc_battery_sim_desc">模拟电量、充电或放电状态，或重置模拟</string>
+    <string name="adb_misc_open_url_title">打开 URL / 深层链接</string>
+    <string name="adb_misc_open_url_desc">在目标设备的浏览器中打开任意网页或深层链接</string>
+    <string name="adb_misc_open_url_placeholder">https://example.com</string>
+
+    <string name="adb_misc_dialog_clear_title">清除活动应用的数据？</string>
+    <string name="adb_misc_dialog_clear_msg">确定要永久清除以下软件包的所有应用数据、登录信息和缓存吗？\n\n%1$s\n\n此操作无法撤销。</string>
+    <string name="adb_misc_dialog_clear_btn">清除数据</string>
+    <string name="adb_misc_dialog_orientation_title">选择屏幕方向</string>
+    <string name="adb_misc_orientation_0">0° 竖屏</string>
+    <string name="adb_misc_orientation_90">90° 向右横屏</string>
+    <string name="adb_misc_orientation_180">180° 倒置竖屏</string>
+    <string name="adb_misc_orientation_270">270° 向左横屏</string>
+    <string name="adb_misc_dialog_density_title">设置屏幕密度（DPI）</string>
+    <string name="adb_misc_density_reading">正在读取当前屏幕密度…</string>
+    <string name="adb_misc_density_presets">预设</string>
+    <string name="adb_misc_density_custom_label">自定义 DPI 值（72 - 1200）</string>
+    <string name="adb_misc_density_invalid">请输入 72 到 1200 之间的有效 DPI</string>
+    <string name="adb_misc_btn_apply">应用</string>
+    <string name="adb_misc_btn_reset_default">恢复默认值</string>
+    <string name="adb_misc_dialog_resolution_title">设置屏幕分辨率</string>
+    <string name="adb_misc_resolution_reading">正在读取当前分辨率…</string>
+    <string name="adb_misc_resolution_width">宽度</string>
+    <string name="adb_misc_resolution_height">高度</string>
+    <string name="adb_misc_resolution_invalid">请输入 240 到 10000 之间的有效尺寸</string>
+    <string name="adb_misc_dialog_stay_awake_title">保持屏幕常亮</string>
+    <string name="adb_misc_dialog_stay_awake_msg">选择是否强制设备屏幕在 USB 连接期间保持亮起。</string>
+    <string name="adb_misc_btn_stay_awake_enable">启用（保持常亮）</string>
+    <string name="adb_misc_btn_stay_awake_disable">停用</string>
+    <string name="adb_misc_dialog_demo_mode_title">演示模式（整洁状态栏）</string>
+    <string name="adb_misc_dialog_demo_mode_msg">将状态栏图标设为 100% 电量、12:00 时间和满格信号，或恢复正常状态栏。</string>
+    <string name="adb_misc_btn_demo_mode_enter">进入演示模式</string>
+    <string name="adb_misc_btn_demo_mode_exit">退出演示模式</string>
+    <string name="adb_misc_dialog_anim_scale_title">选择动画速度</string>
+    <string name="adb_misc_dialog_battery_title">模拟电池状态</string>
+    <string name="adb_misc_battery_level_label">模拟电量</string>
+    <string name="adb_misc_battery_charging_label">模拟充电状态</string>
+    <string name="adb_misc_battery_btn_charging">充电中</string>
+    <string name="adb_misc_battery_btn_discharging">放电中</string>
+    <string name="adb_misc_battery_btn_reset">重置模拟</string>
+    <string name="adb_misc_dialog_open_url_title">在设备上打开 URL</string>
+    <string name="adb_misc_dialog_open_url_msg">输入要在目标设备浏览器中打开的网址或深层链接：</string>
+    <string name="adb_misc_btn_open">打开</string>
+
+    <string name="adb_misc_status_success">状态：成功</string>
+    <string name="adb_misc_status_failed">状态：失败</string>
+    <string name="adb_misc_status_dismiss">关闭</string>
+    <string name="adb_misc_not_connected">设备未连接</string>
+    <string name="adb_misc_no_foreground_app">无法检测目标设备上的活动前台应用。</string>
+    <string name="adb_misc_state_enabled">已启用（开）</string>
+    <string name="adb_misc_state_disabled">已停用（关）</string>
+    <string name="adb_misc_executed_success">执行成功。</string>
+    <string name="adb_misc_btn_reset">重置</string>
 
     <!-- Fastboot 标签页 -->
     <string name="fastboot_tab_actions">操作</string>
@@ -513,6 +635,7 @@
     <string name="touchpad_error_title">虚拟输入错误</string>
     <string name="touchpad_error_desc">无法初始化虚拟鼠标/键盘（/dev/uhid）。如果适用，请确认已启用“开发者选项 &gt; USB 调试（安全设置）”。</string>
 
+
     <!-- 守护进程控制和连接 -->
     <string name="daemon_dialog_title">守护进程响应</string>
     <string name="btn_ok">确定</string>
@@ -562,6 +685,7 @@
     <string name="settings_about_title">关于</string>
     <string name="settings_about_desc">应用信息、社交链接和代码仓库</string>
     <string name="settings_about_version">版本 %1$s</string>
+    <string name="settings_about_documentation">文档</string>
     <string name="settings_about_source_code">源代码</string>
     <string name="cd_github">GitHub</string>
     <string name="cd_telegram">Telegram</string>
@@ -639,10 +763,90 @@
     <string name="adb_ip_placeholder">192.168.1.100 或 192.168.1.100:5555</string>
     <string name="cd_choose_save_location">选择保存位置</string>
     <string name="cd_attach_image">附加镜像</string>
+    <string name="touchpad_error_details">详情：%1$s</string>
     <string name="shell_error_message">Shell 错误：%1$s</string>
     <string name="shell_live_hint">无需在命令前添加“adb shell”，这里已经是设备的实时 Shell。</string>
     <string name="pkg_badge_system">系统</string>
     <string name="pkg_badge_disabled">已停用</string>
     <string name="pkg_badge_splits">拆分（%1$d）</string>
-    <string name="touchpad_error_details">详情：%1$s</string>
+
+    <string name="btn_refresh">刷新</string>
+    <string name="btn_retry">重试</string>
+
+    <!-- 进程管理器 -->
+    <string name="proc_manager_title">进程管理器</string>
+    <string name="proc_manager_subtitle">实时监控 CPU/内存，并查看和管理运行中的进程</string>
+    <string name="proc_manager_ram_usage">系统内存</string>
+    <string name="proc_manager_ram_used_format">%1$s / %2$s（已使用 %3$d%%）</string>
+    <string name="proc_manager_cpu_usage">CPU 使用率</string>
+    <string name="proc_manager_cpu_format">%1$s · %2$d 核</string>
+    <string name="proc_manager_processes_count">%1$d 个进程（%2$d 个应用，%3$d 个系统进程）</string>
+    <string name="proc_manager_search_placeholder">搜索进程、应用或 PID…</string>
+    <string name="proc_filter_all">全部（%1$d）</string>
+    <string name="proc_filter_apps">应用（%1$d）</string>
+    <string name="proc_filter_system">系统（%1$d）</string>
+    <string name="proc_sort_ram">内存（从高到低）</string>
+    <string name="proc_sort_cpu">CPU（从高到低）</string>
+    <string name="proc_sort_pid">PID（从低到高）</string>
+    <string name="proc_sort_name">名称（A 到 Z）</string>
+    <string name="proc_action_force_stop">强制停止</string>
+    <string name="proc_action_kill_pid">终止 PID</string>
+    <string name="proc_btn_force_stop">强制停止</string>
+    <string name="proc_btn_kill">终止</string>
+    <string name="proc_dialog_force_stop_title">强制停止 %1$s？</string>
+    <string name="proc_dialog_force_stop_msg">强制停止此应用将立即终止其所有活动进程和后台服务。</string>
+    <string name="proc_dialog_kill_pid_title">终止进程 %1$s（PID %2$d）？</string>
+    <string name="proc_dialog_kill_pid_msg">发送 SIGKILL（信号 9）将立即终止此进程，未保存的数据可能会丢失。</string>
+    <string name="proc_toast_force_stop_success">已强制停止 %1$s</string>
+    <string name="proc_toast_force_stop_failed">强制停止 %1$s 失败：%2$s</string>
+    <string name="proc_toast_kill_success">已终止 PID %1$d</string>
+    <string name="proc_toast_kill_failed">终止 PID %1$d 失败：%2$s</string>
+    <string name="proc_auto_refresh_on">自动刷新（开）</string>
+    <string name="proc_auto_refresh_off">自动刷新（关）</string>
+    <string name="proc_empty_list">未找到匹配的进程。</string>
+    <string name="proc_loading">正在连接 DioxAgent 并加载进程…</string>
+    <string name="proc_badge_threads">%1$d 个线程</string>
+    <string name="proc_badge_pid">PID：%1$d</string>
+    <string name="proc_badge_uid">UID：%1$d</string>
+    <string name="proc_badge_cpu">CPU %1$s</string>
+
+    <!-- scrcpy 录制 -->
+    <string name="scrcpy_tab_recordings">录制</string>
+    <string name="scrcpy_recording_started">已开始录制</string>
+    <string name="scrcpy_recording_stopped">录制内容已保存</string>
+    <string name="scrcpy_recording_empty">暂无录制内容</string>
+    <string name="scrcpy_recording_empty_subtitle">录制镜像会话后，录制内容将显示在此处</string>
+    <string name="scrcpy_recording_delete_confirm">删除此录制内容？</string>
+    <string name="scrcpy_recording_delete_confirm_msg">此操作无法撤销。</string>
+    <string name="scrcpy_recording_exported">录制内容已导出</string>
+    <string name="scrcpy_recording_export_failed">导出失败</string>
+    <string name="scrcpy_recording_deleted">录制内容已删除</string>
+    <string name="scrcpy_recording_codec_warning">此编解码器不支持录制</string>
+    <string name="scrcpy_recording_elapsed">录制 %1$s</string>
+    <string name="btn_delete">删除</string>
+    <string name="btn_export">导出</string>
+    <string name="settings_scrcpy_auto_record_title">自动录制会话</string>
+    <string name="settings_scrcpy_auto_record_subtitle">镜像开始时自动开始录制</string>
+
+    <!-- 杂项设置与后台常驻 -->
+    <string name="settings_misc_title">杂项</string>
+    <string name="settings_misc_desc">后台行为和常规选项</string>
+    <string name="settings_keep_alive_title">后台常驻</string>
+    <string name="settings_keep_alive_desc">应用最小化时保持后台服务运行，以维持设备连接</string>
+    <string name="notification_channel_keep_alive_name">后台常驻服务</string>
+    <string name="notification_channel_keep_alive_desc">Dioxamine 在后台保持运行时显示的通知</string>
+    <string name="notification_keep_alive_title">Dioxamine 后台常驻</string>
+    <string name="notification_keep_alive_text">Dioxamine 正在后台运行</string>
+    <string name="notification_keep_alive_no_devices">未连接设备 &#8226; 正在后台运行</string>
+    <plurals name="notification_adb_devices">
+        <item quantity="one">已连接 %1$d 台 ADB 设备</item>
+        <item quantity="other">已连接 %1$d 台 ADB 设备</item>
+    </plurals>
+    <plurals name="notification_fastboot_devices">
+        <item quantity="one">已连接 %1$d 台 Fastboot 设备</item>
+        <item quantity="other">已连接 %1$d 台 Fastboot 设备</item>
+    </plurals>
+    <string name="notification_keep_alive_stop_action">停止</string>
+    <string name="settings_battery_opt_denied_warning">未停用电池优化，后台连接可能会在低电耗模式下暂停。</string>
+    <string name="settings_notif_perm_denied_warning">通知权限已被拒绝，将无法看到后台状态通知。</string>
 </resources>


### PR DESCRIPTION
feat(i18n): add zh-CN strings for device utilities

- Add ADB misc tool labels in values-zh-rCN/strings.xml
- Localize process manager controls and shared refresh actions
- Add package permission, theme, docs, and API requirement copy